### PR TITLE
Implement candle check for Beta Berserker quest

### DIFF
--- a/Other/Various/BetaBerserkerQuest.cs
+++ b/Other/Various/BetaBerserkerQuest.cs
@@ -6,11 +6,15 @@ tags: beta berserker armor, dark berserker, beta berserker, secret map, rare, ps
 //cs_include Scripts/CoreBots.cs
 using Skua.Core.Interfaces;
 using Skua.Core.Models.Items;
+using System.Linq;
 
 public class SecretMapQuest
 {
     private IScriptInterface Bot => IScriptInterface.Instance;
     private CoreBots Core => CoreBots.Instance;
+
+    private const int CandleShopId = 1317;
+    private const string CandleName = "Golden 8th Birthday Candle";
 
     public void ScriptMain(IScriptInterface Bot)
     {
@@ -24,14 +28,20 @@ public class SecretMapQuest
     public void DoQuest()
     {
         InventoryItem? BetaBerserker = Bot.Inventory.Items.Find(i =>
-            i.Name.ToLower().Trim() == ("Beta Berserker").ToLower().Trim()
+            i.Name.ToLower().Trim() == "Beta Berserker"
             && i.Category == ItemCategory.Class
         );
 
         if (BetaBerserker == null || Core.CheckInventory(Core.QuestRewards(5516)))
             return;
+
+        // Check/Buy Candle before proceeding
+        if (!EnsureGolden8thBirthdayCandle())
+            return;
+
         Core.Unbank("Beta Berserker");
         Core.AddDrop(Core.QuestRewards(5516));
+
         while (!Core.CheckInventory(Core.QuestRewards(5516)))
         {
             while (BetaBerserker != null && BetaBerserker.Quantity < 1)
@@ -41,5 +51,35 @@ public class SecretMapQuest
             Core.HuntMonster("nostalgiaquest", "Boss Zardman", "Secret Map");
             Core.EnsureComplete(5516);
         }
+    }
+
+    private bool EnsureGolden8thBirthdayCandle()
+    {
+
+        if (Core.CheckInventory(CandleName))
+            return true;
+
+        Bot.Shops.Load(CandleShopId);
+
+        bool inShop = Bot.Shops.Items != null &&
+                      Bot.Shops.Items.Any(i => i != null &&
+                          i.Name.Equals(CandleName, System.StringComparison.OrdinalIgnoreCase));
+
+        if (!inShop)
+        {
+            Core.Logger("You account needs to be at least 8 years old to complete this quest.");
+            return false;
+        }
+
+        Bot.Shops.BuyItem(CandleName, CandleShopId);
+        Bot.Wait.ForPickup(CandleName);
+
+        if (!Core.CheckInventory(CandleName))
+        {
+            Core.Logger("You account needs to be at least 8 years old to complete this quest.");
+            return false;
+        }
+
+        return true;
     }
 }


### PR DESCRIPTION
Added functionality to ensure the player has a Golden 8th Birthday Candle before proceeding with the quest.

This is required by the quest to be completed, despite not being stated on the Wiki - probably because it does not take people who IODAd Beta Berserker to consideration.