### PR TITLE
Adding remaining Ultra Auto-Comps, Using correct UpdateEntry, Updating Aciel w/ GetYaSoulsHeeeere

### DIFF
--- a/Hollowborn/MergeShops/AcielsGiftsMerge.cs
+++ b/Hollowborn/MergeShops/AcielsGiftsMerge.cs
@@ -6,6 +6,11 @@ tags: aciels, gifts, merge, shadowrealm, hollow, hail, next, week, ac, items
 //cs_include Scripts/CoreBots.cs
 //cs_include Scripts/CoreFarms.cs
 //cs_include Scripts/CoreAdvanced.cs
+//cs_include Scripts/CoreStory.cs
+//cs_include Scripts/Hollowborn/CoreHollowborn.cs
+//cs_include Scripts/Story/Hollowborn/CoreHollowbornStory.cs
+//cs_include Scripts/Nation/CoreNation.cs
+//cs_include Scripts/Hollowborn/Materials/HollowSoul.cs
 using Skua.Core.Interfaces;
 using Skua.Core.Models.Items;
 using Skua.Core.Options;
@@ -20,6 +25,8 @@ public class AcielsGiftsMerge
     private static CoreAdvanced _Adv;
     private static CoreAdvanced sAdv { get => _sAdv ??= new CoreAdvanced(); set => _sAdv = value; }
     private static CoreAdvanced _sAdv;
+    private static HollowSoul HS { get => _HS ??= new HollowSoul(); set => _HS = value; }
+    private static HollowSoul _HS;
 
 
     public bool DontPreconfigure = true;
@@ -67,16 +74,7 @@ public class AcielsGiftsMerge
                 #region Known items
 
                 case "Hollow Soul":
-                    Core.FarmingLogger(req.Name, quant);
-                    Core.EquipClass(ClassType.Farm);
-                    while (!Bot.ShouldExit && !Core.CheckInventory(req.Name, quant))
-                    {
-                        Core.EnsureAcceptmultiple(new[] { 7553, 7555 });
-                        Core.KillMonster("shadowrealm", "r2", "Left", "Gargrowl", "Darkseed", 8, log: false);
-                        Core.KillMonster("shadowrealm", "r2", "Left", "Shadow Guardian", "Shadow Medallion", 5, log: false);
-                        Core.EnsureComplete(new[] { 7553, 7555 });
-                    }
-                    Bot.Wait.ForPickup(req.Name);
+                    HS.GetYaSoulsHeeeere(quant);
                     break;
                 #endregion
 

--- a/Ultras/CoreUltra.cs
+++ b/Ultras/CoreUltra.cs
@@ -758,74 +758,70 @@ public class CoreUltra
         if (string.IsNullOrWhiteSpace(key))
             return;
 
-        string lockFile = path + ".lock";
-        FileStream? lockStream = null;
-
-        try
+        for (int attempt = 0; attempt < 50; attempt++)
         {
-            // Acquire exclusive lock file
-            for (int attempt = 0; attempt < 50; attempt++)
+            try
             {
-                try
+                // Phase 1: Read existing content (shared lock)
+                List<string> lines = new List<string>();
+                
+                if (File.Exists(path))
                 {
-                    lockStream = new FileStream(
-                        lockFile,
-                        FileMode.OpenOrCreate,
-                        FileAccess.ReadWrite,
-                        FileShare.None
-                    );
-                    break; // Got the lock
+                    using (var fs = new FileStream(
+                        path,
+                        FileMode.Open,
+                        FileAccess.Read,
+                        FileShare.Read))
+                    using (var reader = new StreamReader(fs))
+                    {
+                        string? line;
+                        while ((line = reader.ReadLine()) != null)
+                        {
+                            if (!string.IsNullOrWhiteSpace(line))
+                                lines.Add(line);
+                        }
+                    }
                 }
-                catch (IOException)
+
+                // Phase 2: Modify in memory
+                string stamp = DateTimeOffset.UtcNow.ToUnixTimeSeconds().ToString();
+                string entry = $"{key}:{payload}:{stamp}";
+
+                int idx = lines.FindIndex(l =>
                 {
-                    Bot?.Sleep(100 + (attempt * 20)); // Backoff
+                    string[] parts = l.Split(':');
+                    return parts.Length > 0 && 
+                        parts[0].Equals(key, StringComparison.OrdinalIgnoreCase);
+                });
+
+                if (idx >= 0)
+                    lines[idx] = entry;
+                else
+                    lines.Add(entry);
+
+                // Phase 3: Write with exclusive lock
+                using (var fs = new FileStream(
+                    path,
+                    FileMode.Create, // Truncate and write
+                    FileAccess.Write,
+                    FileShare.None)) // EXCLUSIVE - blocks everyone
+                using (var writer = new StreamWriter(fs))
+                {
+                    foreach (var line in lines)
+                    {
+                        writer.WriteLine(line);
+                    }
                 }
+                
+                return; // Success
             }
-
-            if (lockStream == null)
+            catch (IOException)
             {
-                Bot?.Log($"[UpdateEntry] Failed to acquire lock for {path}");
-                return;
-            }
-
-            // Now we have exclusive access - read, modify, write
-            List<string> lines = ReadLines(path).ToList();
-            string stamp = DateTimeOffset.UtcNow.ToUnixTimeSeconds().ToString();
-            string entry = $"{key}:{payload}:{stamp}";
-
-            int idx = lines.FindIndex(l =>
-            {
-                string[] parts = l.Split(':');
-                if (parts.Length < 1)
-                    return false;
-                return parts[0].Equals(key, StringComparison.OrdinalIgnoreCase);
-            });
-
-            if (idx >= 0)
-                lines[idx] = entry;
-            else
-                lines.Add(entry);
-
-            // Write back
-            string[] arr = lines.ToArray();
-            for (int i = 0; i < 10; i++)
-            {
-                try
-                {
-                    File.WriteAllLines(path, arr);
-                    break;
-                }
-                catch (IOException)
-                {
-                    Bot?.Sleep(50);
-                }
+                Bot?.Sleep(100 + (attempt * 20));
             }
         }
-        finally
-        {
-            // Release lock
-            lockStream?.Dispose();
-        }
+        
+        Bot?.Log($"[ArmySync] Failed to update {path} after retries");
     }
 
     // -------------------------------------------------------

--- a/Ultras/UltraAvatarTyndarius.cs
+++ b/Ultras/UltraAvatarTyndarius.cs
@@ -83,6 +83,16 @@ public class UltraAvatarTyndarius
     public string OptionsStorage = "UltraAvatarTyndarius3";
     public List<IOption> Options = new()
     {
+        new Option<TyndariusComp>(
+            "DoEquipClasses",
+            "Automatically Equip Classes",
+            "Auto-equip classes across all 4 clients\n"
+                + "Safe: CAv / LR / AP / LOO\n"
+                + "Fast: CSS / LR / AP / LOO\n"
+                + "F2PFast: KE / LR / AP / LOO\n"
+                + "Unselected = off (use whatever classes you already have equipped).",
+            TyndariusComp.Unselected
+        ),
         // Ball 1 Taunter selection
         new Option<Ball1Taunter>(
             "Ball1Taunter",
@@ -152,6 +162,20 @@ public class UltraAvatarTyndarius
 
     void Prep()
     {
+        // Sync-equip classes if a comp is selected
+        TyndariusComp comp = Bot.Config!.Get<TyndariusComp>("DoEquipClasses");
+        if (comp != TyndariusComp.Unselected)
+        {
+            string[] classes = comp switch
+            {
+                TyndariusComp.Safe => new[] { "Chaos Avenger", "Legion Revenant", "ArchPaladin", "Lord Of Order" },
+                TyndariusComp.Fast => new[] { "Chrono ShadowSlayer", "Legion Revenant", "ArchPaladin", "Lord Of Order" },
+                TyndariusComp.F2PFast => new[] { "King's Echo", "Legion Revenant", "ArchPaladin", "Lord Of Order" },
+            };
+
+            Ultra.EquipClassSync(classes, 4, "tyndarius_class.sync");
+        }
+
         if (Bot.Config!.Get<bool>("DoEnh"))
             DoEnh();
         Ultra.UseAlchemyPotions(Ultra.GetBestTonicPotion(), Ultra.GetBestElixirPotion());
@@ -371,6 +395,14 @@ public class UltraAvatarTyndarius
                 Adv.SmartEnhance(Bot.Player.CurrentClass!.Name);
                 break;
         }
+    }
+
+    public enum TyndariusComp
+    {
+        Unselected,
+        Safe,
+        Fast,
+        F2PFast,
     }
 
     public enum Ball2killer

--- a/Ultras/UltraDarkon.cs
+++ b/Ultras/UltraDarkon.cs
@@ -67,6 +67,14 @@ public class UltraDarkon
     // User options
     public List<IOption> Options = new()
     {
+        new Option<DarkonComp>(
+            "DoEquipClasses",
+            "Automatically Equip Classes",
+            "Auto-equip classes across all 4 clients\n"
+                + "Recommended: LC / LR / LOO / SC\n"
+                + "Unselected = off (use whatever classes you already have equipped).",
+            DarkonComp.Unselected
+        ),
         new Option<bool>("DoEnh", "Do Enhancements",  "Auto-Enhance Gear properly for the fight", true),
         CoreBots.Instance.SkipOptions,
     };
@@ -90,6 +98,18 @@ public class UltraDarkon
             && !Bot.Config.Get<bool>(C.SkipOptions)
         )
             Bot.Config.Configure();
+
+        // Sync-equip classes if a comp is selected
+        DarkonComp comp = Bot.Config!.Get<DarkonComp>("DoEquipClasses");
+        if (comp != DarkonComp.Unselected)
+        {
+            string[] classes = comp switch
+            {
+                DarkonComp.Recommended => new[] { "LightCaster", "Legion Revenant", "Lord Of Order", "StoneCrusher" },
+            };
+
+            Ultra.EquipClassSync(classes, 4, "darkon_class.sync");
+        }
 
         if (Bot.Player.CurrentClass?.Name == "Alpha Omega" || Bot.Player.CurrentClass?.Name == "Alpha DOOMmega")
             taunting = false;
@@ -292,5 +312,11 @@ public class UltraDarkon
                 );
                 break;
         }
+    }
+
+    public enum DarkonComp
+    {
+        Unselected,
+        Recommended,
     }
 }

--- a/Ultras/UltraEngineer.cs
+++ b/Ultras/UltraEngineer.cs
@@ -155,6 +155,16 @@ public class UltraEngineer
     public string OptionsStorage = "UltraEngineer";
     public List<IOption> Options = new()
     {
+        new Option<EngineerComp>(
+            "DoEquipClasses",
+            "Automatically Equip Classes",
+            "Auto-equip classes across all 4 clients\n"
+                + "Fast: Lich / LR / AP / LOO\n"
+                + "Safe: LR / SC / AP / LOO\n"
+                + "F2PFast: AI / LR / AP / LOO\n"
+                + "Unselected = off (use whatever classes you already have equipped).",
+            EngineerComp.Unselected
+        ),
         new Option<bool>("DoEnh", "Do Enhancements",  "Auto-Enhance Gear properly for the fight", true),
         CoreBots.Instance.SkipOptions,
     };
@@ -179,6 +189,20 @@ public class UltraEngineer
 
     void Prep()
     {
+        // Sync-equip classes if a comp is selected
+        EngineerComp comp = Bot.Config!.Get<EngineerComp>("DoEquipClasses");
+        if (comp != EngineerComp.Unselected)
+        {
+            string[] classes = comp switch
+            {
+                EngineerComp.Fast => new[] { "Lich", "Legion Revenant", "ArchPaladin", "Lord Of Order" },
+                EngineerComp.Safe => new[] { "Legion Revenant", "StoneCrusher", "ArchPaladin", "Lord Of Order" },
+                EngineerComp.F2PFast => new[] { "Arcana Invoker", "Legion Revenant", "ArchPaladin", "Lord Of Order" },
+            };
+
+            Ultra.EquipClassSync(classes, 4, "engineer_class.sync");
+        }
+
         if (Bot.Config!.Get<bool>("DoEnh"))
         {
             Adv.GearStore(false, true);
@@ -339,5 +363,13 @@ public class UltraEngineer
                 );
                 break;
         }
+    }
+
+    public enum EngineerComp
+    {
+        Unselected,
+        Fast,
+        Safe,
+        F2PFast,
     }
 }

--- a/Ultras/UltraEzrajal.cs
+++ b/Ultras/UltraEzrajal.cs
@@ -166,6 +166,16 @@ public class UltraEzrajal
     public bool DontPreconfigure = true;
     public List<IOption> Options = new()
     {
+        new Option<EzrajalComp>(
+            "DoEquipClasses",
+            "Automatically Equip Classes",
+            "Auto-equip classes across all 4 clients\n"
+                + "Fast: CSS / VDK / LR / LOO\n"
+                + "Safe: AI / LR / AP / LOO\n"
+                + "F2PFastest: AI / VDK / LR / LOO\n"
+                + "Unselected = off (use whatever classes you already have equipped).",
+            EzrajalComp.Unselected
+        ),
         new Option<bool>("DoEnh", "Do Enhancements",  "Auto-Enhance Gear properly for the fight", true),
         CoreBots.Instance.SkipOptions,
     };
@@ -190,6 +200,20 @@ public class UltraEzrajal
 
     void Prep()
     {
+        // Sync-equip classes if a comp is selected
+        EzrajalComp comp = Bot.Config!.Get<EzrajalComp>("DoEquipClasses");
+        if (comp != EzrajalComp.Unselected)
+        {
+            string[] classes = comp switch
+            {
+                EzrajalComp.Fast => new[] { "Chrono ShadowSlayer", "Verus DoomKnight", "Legion Revenant", "Lord Of Order" },
+                EzrajalComp.Safe => new[] { "Arcana Invoker", "Legion Revenant", "ArchPaladin", "Lord Of Order" },
+                EzrajalComp.F2PFastest => new[] { "Arcana Invoker", "Verus DoomKnight", "Legion Revenant", "Lord Of Order" },
+            };
+
+            Ultra.EquipClassSync(classes, 4, "ezrajal_class.sync");
+        }
+
         if (Bot.Config!.Get<bool>("DoEnh"))
         {
             Adv.GearStore(false, true);
@@ -360,5 +384,13 @@ public class UltraEzrajal
                 );
                 break;
         }
+    }
+
+    public enum EzrajalComp
+    {
+        Unselected,
+        Fast,
+        Safe,
+        F2PFastest,
     }
 }

--- a/Ultras/UltraGramiel.cs
+++ b/Ultras/UltraGramiel.cs
@@ -404,7 +404,7 @@ public class UltraGramiel
                     type: EnhancementType.Lucky,
                     hSpecial: HelmSpecial.Forge,
                     wSpecial: WeaponSpecial.Arcanas_Concerto,
-                    cSpecial: CapeSpecial.Absolution
+                    cSpecial: CapeSpecial.Penitence
                 );
                 break;
 
@@ -414,7 +414,7 @@ public class UltraGramiel
                     type: EnhancementType.Lucky,
                     hSpecial: HelmSpecial.Pneuma,
                     wSpecial: WeaponSpecial.Ravenous,
-                    cSpecial: CapeSpecial.Vainglory
+                    cSpecial: CapeSpecial.Penitence
                 );
                 break;
 

--- a/Ultras/UltraGramiel.cs
+++ b/Ultras/UltraGramiel.cs
@@ -90,6 +90,14 @@ public class UltraGramiel
 
     public List<IOption> Options = new()
     {
+        new Option<GramielComp>(
+            "DoEquipClasses",
+            "Automatically Equip Classes",
+            "Auto-equip classes across all 4 clients\n"
+                + "Recommended: SC / LC / LOO / VDK\n"
+                + "Unselected = off (use whatever classes you already have equipped).",
+            GramielComp.Unselected
+        ),
         new Option<CustomRole>(
             "CustomRole",
             "Custom Role",
@@ -142,6 +150,23 @@ public class UltraGramiel
 
     void Prep(bool skipEnhancements = false)
     {
+        // Sync-equip classes if a comp is selected
+        GramielComp comp = Bot.Config!.Get<GramielComp>("DoEquipClasses");
+        if (comp != GramielComp.Unselected)
+        {
+            string[][] classes = comp switch
+            {
+                GramielComp.Recommended => new[] {
+                    new[] { "StoneCrusher", "Infinity Titan" },
+                    new[] { "LightCaster" },
+                    new[] { "Lord Of Order" },
+                    new[] { "Verus DoomKnight" }
+                },
+            };
+
+            Ultra.EquipClassSync(classes, 4, "gramiel_class.sync");
+        }
+
         if (Bot.Config!.Get<bool>("DoEnh") && !skipEnhancements)
             DoEnhs();
 
@@ -367,7 +392,7 @@ public class UltraGramiel
             case "infinity titan":
                 Adv.EnhanceEquipped(
                     type: EnhancementType.Fighter,
-                    hSpecial: HelmSpecial.None,
+                    hSpecial: HelmSpecial.Anima,
                     wSpecial: WeaponSpecial.Valiance,
                     cSpecial: CapeSpecial.Absolution
                 );
@@ -379,7 +404,7 @@ public class UltraGramiel
                     type: EnhancementType.Lucky,
                     hSpecial: HelmSpecial.Forge,
                     wSpecial: WeaponSpecial.Arcanas_Concerto,
-                    cSpecial: CapeSpecial.Penitence
+                    cSpecial: CapeSpecial.Absolution
                 );
                 break;
 
@@ -389,7 +414,7 @@ public class UltraGramiel
                     type: EnhancementType.Lucky,
                     hSpecial: HelmSpecial.Pneuma,
                     wSpecial: WeaponSpecial.Ravenous,
-                    cSpecial: CapeSpecial.Penitence
+                    cSpecial: CapeSpecial.Vainglory
                 );
                 break;
 
@@ -606,6 +631,12 @@ public class UltraGramiel
             }
         }
         catch { }
+    }
+
+    public enum GramielComp
+    {
+        Unselected,
+        Recommended,
     }
 
     public enum CustomRole

--- a/Ultras/UltraWarden.cs
+++ b/Ultras/UltraWarden.cs
@@ -32,6 +32,14 @@ public class UltraWarden
     public string OptionsStorage = "UltraWarden";
     public List<IOption> Options = new()
     {
+        new Option<WardenComp>(
+            "DoEquipClasses",
+            "Automatically Equip Classes",
+            "Auto-equip classes across all 4 clients\n"
+                + "Recommended: LR / AP / LOO / VDK\n"
+                + "Unselected = off (use whatever classes you already have equipped).",
+            WardenComp.Unselected
+        ),
         new Option<string>("a", "Taunter Class (Primary)", "Class name that will taunt first", ""),
         new Option<string>("b", "Taunter Class (Backup)", "Backup taunter class", ""),
         new Option<bool>("DoEnh", "Do Enhancements",  "Auto-Enhance Gear properly for the fight", true),
@@ -69,6 +77,18 @@ public class UltraWarden
 
     void Prep()
     {
+        // Sync-equip classes if a comp is selected
+        WardenComp comp = Bot.Config!.Get<WardenComp>("DoEquipClasses");
+        if (comp != WardenComp.Unselected)
+        {
+            string[] classes = comp switch
+            {
+                WardenComp.Recommended => new[] { "Legion Revenant", "ArchPaladin", "Lord Of Order", "Verus DoomKnight" },
+            };
+
+            Ultra.EquipClassSync(classes, 4, "warden_class.sync");
+        }
+
         Ultra.UseAlchemyPotions(Ultra.GetBestTonicPotion(), Ultra.GetBestElixirPotion());
         if (IsTaunter())
             Ultra.GetScrollOfEnrage();
@@ -116,5 +136,11 @@ public class UltraWarden
             Bot.Combat.Attack("*");
             Bot.Sleep(250);
         }
+    }
+
+    public enum WardenComp
+    {
+        Unselected,
+        Recommended,
     }
 }


### PR DESCRIPTION
## Summary by Sourcery

Improve concurrent file update handling and add synchronized auto-equip class presets for multiple Ultra encounter scripts, along with delegating Hollow Soul acquisition to a shared helper.

New Features:
- Add synchronized auto-equip class composition options to Gramiel, Avatar Tyndarius, Engineer, Ezrajal, Darkon, and Warden scripts.
- Introduce configurable class composition enums for each supported Ultra fight to drive the new auto-equip behavior.

Bug Fixes:
- Replace custom lock file usage in CoreUltra.UpdateEntry with a retrying read-modify-write pattern that uses file sharing modes for safer concurrent access.

Enhancements:
- Adjust Infinity Titan enhancement setup to use Anima helm special instead of none.
- Refactor AcielsGiftsMerge Hollow Soul farming to use the centralized HollowSoul helper script.