### PR TITLE
Removing duplicate syncPath

### DIFF
--- a/Ultras/UltraGramiel.cs
+++ b/Ultras/UltraGramiel.cs
@@ -363,7 +363,6 @@ public class UltraGramiel
                 
                 Core.Join("whitemap");
                 Bot.Wait.ForMapLoad("whitemap");
-                string syncPath = Ultra.ResolveSyncPath("UltraItemCheck.sync");
                 Ultra.ClearSyncFile(syncPath);
                 Bot.Sleep(2500);
                 Prep(skipEnhancements: true);


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Avoid potential variable shadowing by reusing existing syncPath instead of redeclaring it.