### PR TITLE
Swordhaven rep 10

### DIFF
--- a/CoreFarms.cs
+++ b/CoreFarms.cs
@@ -4018,7 +4018,7 @@ public class CoreFarms
         Core.SavedState(false);
     }
 
-    public void SwordhavenREP(int rank = 11)
+    public void SwordhavenREP(int rank = 10)
     {
         if (FactionRank("Swordhaven") >= rank)
             return;


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Fix the Swordhaven reputation helper so it stops at rank 10 instead of rank 11 by default.