### PR TITLE
Add DoAllUltrasStory.cs. Script that completes all Ultra boss story prerequisites

### DIFF
--- a/Story/DoAllUltrasStory.cs
+++ b/Story/DoAllUltrasStory.cs
@@ -25,6 +25,12 @@ public class DoAllUltrasStory
 {
     public IScriptInterface Bot => IScriptInterface.Instance;
     public CoreBots Core => CoreBots.Instance;
+    private static CoreFarms Farm
+    {
+        get => _Farm ??= new CoreFarms();
+        set => _Farm = value;
+    }
+    private static CoreFarms _Farm;
     private static ExaltiaTower Exaltia => _Exaltia ??= new ExaltiaTower();
     private static ExaltiaTower _Exaltia;
     private static CoreSoW SoW => _SoW ??= new CoreSoW();
@@ -48,6 +54,11 @@ public class DoAllUltrasStory
 
     public void DoAllUltrasPrereqs()
     {
+        // Ultra Nulgath  → Level 80 only, no story required
+        // Ultra Gramiel  → Level 80 only, no story required
+        Core.Logger("Leveling to 80 for Ultra Nulgath / Gramiel");
+        Farm.Experience(80);
+
         // Unlocks: Ultra Ezrajal, Ultra Warden, Ultra Engineer
         Core.Logger("Exaltia Tower story → Ultra Ezrajal / Warden / Engineer");
         Exaltia.StoryLine();
@@ -67,8 +78,5 @@ public class DoAllUltrasStory
         // Unlocks: Ultra Drago (AstraviaJudgement / Mahapadma) + Ultra Darkon (TheWorld)
         Core.Logger("Elegy of Madness / Astravia story → Ultra Drago + Ultra Darkon");
         Astravia.CompleteCoreAstravia();
-
-        // Ultra Nulgath  → Level 80 only, no story required
-        // Ultra Gramiel  → Level 80 only, no story required
     }
 }

--- a/Story/DoAllUltrasStory.cs
+++ b/Story/DoAllUltrasStory.cs
@@ -1,0 +1,111 @@
+/*
+name: Do All Ultras Story Prerequisites
+description: Completes all story prerequisites needed to unlock every Ultra boss.
+             Covers: Ultra Ezrajal, Ultra Warden, Ultra Engineer (ExaltiaTower),
+                     Ultra Avatar Tyndarius + Ultra Speaker (Shadows of War),
+                     Ultra Dage (Isle of Fotia),
+                     Champion Drakath (13 Lords of Chaos),
+                     Ultra Drago + Ultra Darkon (Elegy of Madness / Astravia).
+             Skipped: Ultra Nulgath and Ultra Gramiel (Level 80 only, no story required).
+tags: story, quest, ultra, ezrajal, warden, engineer, tyndarius, speaker, dage, drakath, darkon, drago, all, complete
+*/
+//cs_include Scripts/CoreBots.cs
+//cs_include Scripts/CoreFarms.cs
+//cs_include Scripts/CoreStory.cs
+//cs_include Scripts/CoreAdvanced.cs
+//cs_include Scripts/Story/ExaltiaTower.cs
+//cs_include Scripts/Story/ShadowsOfWar/CoreSoW.cs
+//cs_include Scripts/Story/IsleOfFotia/CoreIsleOfFotia.cs
+//cs_include Scripts/Story/LordsofChaos/Core13LoC.cs
+//cs_include Scripts/Story/ElegyofMadness(Darkon)/CoreAstravia.cs
+using Skua.Core.Interfaces;
+
+public class DoAllUltrasStory
+{
+    public IScriptInterface Bot => IScriptInterface.Instance;
+    public CoreBots Core => CoreBots.Instance;
+    private static CoreStory Story
+    {
+        get => _Story ??= new CoreStory();
+        set => _Story = value;
+    }
+    private static CoreStory _Story;
+    private static ExaltiaTower Exaltia
+    {
+        get => _Exaltia ??= new ExaltiaTower();
+        set => _Exaltia = value;
+    }
+    private static ExaltiaTower _Exaltia;
+    private static CoreSoW SoW
+    {
+        get => _SoW ??= new CoreSoW();
+        set => _SoW = value;
+    }
+    private static CoreSoW _SoW;
+    private static CoreIsleOfFotia Fotia
+    {
+        get => _Fotia ??= new CoreIsleOfFotia();
+        set => _Fotia = value;
+    }
+    private static CoreIsleOfFotia _Fotia;
+    private static Core13LoC LoC
+    {
+        get => _LoC ??= new Core13LoC();
+        set => _LoC = value;
+    }
+    private static Core13LoC _LoC;
+    private static CoreAdvanced Adv
+    {
+        get => _Adv ??= new CoreAdvanced();
+        set => _Adv = value;
+    }
+    private static CoreAdvanced _Adv;
+    private static CoreFarms Farm
+    {
+        get => _Farm ??= new CoreFarms();
+        set => _Farm = value;
+    }
+    private static CoreFarms _Farm;
+    private static CoreAstravia Astravia
+    {
+        get => _Astravia ??= new CoreAstravia();
+        set => _Astravia = value;
+    }
+    private static CoreAstravia _Astravia;
+
+    public void ScriptMain(IScriptInterface bot)
+    {
+        Core.SetOptions();
+        Core.EquipClass(ClassType.Solo);
+
+        DoAllUltrasPrereqs();
+
+        Core.SetOptions(false);
+    }
+
+    public void DoAllUltrasPrereqs()
+    {
+        // Unlocks: Ultra Ezrajal, Ultra Warden, Ultra Engineer
+        Core.Logger("Exaltia Tower story → Ultra Ezrajal / Warden / Engineer");
+        Exaltia.StoryLine();
+
+        // Unlocks: Ultra Avatar Tyndarius (Tyndarius step) + Ultra Speaker (ManaCradle step)
+        Core.Logger("Shadows of War story → Ultra Avatar Tyndarius + Ultra Speaker");
+        SoW.CompleteCoreSoW();
+
+        // Unlocks: Ultra Dage
+        Core.Logger("Isle of Fotia story → Ultra Dage");
+        Fotia.CompleteALL();
+
+        // Unlocks: Champion Drakath
+        Core.Logger("13 Lords of Chaos story → Champion Drakath");
+        LoC.Complete13LOC(true);
+
+        // Unlocks: Ultra Drago (AstraviaJudgement / Mahapadma) + Ultra Darkon (TheWorld)
+        Core.Logger("Elegy of Madness / Astravia story → Ultra Drago + Ultra Darkon");
+        Astravia.CompleteCoreAstravia();
+
+        // Ultra Nulgath  → Level 80 only, no story required
+        // Ultra Gramiel  → Level 80 only, no story required
+    }
+}

--- a/Story/DoAllUltrasStory.cs
+++ b/Story/DoAllUltrasStory.cs
@@ -10,9 +10,6 @@ description: Completes all story prerequisites needed to unlock every Ultra boss
 tags: story, quest, ultra, ezrajal, warden, engineer, tyndarius, speaker, dage, drakath, darkon, drago, all, complete
 */
 //cs_include Scripts/CoreBots.cs
-//cs_include Scripts/CoreFarms.cs
-//cs_include Scripts/CoreStory.cs
-//cs_include Scripts/CoreAdvanced.cs
 //cs_include Scripts/Story/ExaltiaTower.cs
 //cs_include Scripts/Story/ShadowsOfWar/CoreSoW.cs
 //cs_include Scripts/Story/IsleOfFotia/CoreIsleOfFotia.cs
@@ -24,53 +21,15 @@ public class DoAllUltrasStory
 {
     public IScriptInterface Bot => IScriptInterface.Instance;
     public CoreBots Core => CoreBots.Instance;
-    private static CoreStory Story
-    {
-        get => _Story ??= new CoreStory();
-        set => _Story = value;
-    }
-    private static CoreStory _Story;
-    private static ExaltiaTower Exaltia
-    {
-        get => _Exaltia ??= new ExaltiaTower();
-        set => _Exaltia = value;
-    }
+    private static ExaltiaTower Exaltia => _Exaltia ??= new ExaltiaTower();
     private static ExaltiaTower _Exaltia;
-    private static CoreSoW SoW
-    {
-        get => _SoW ??= new CoreSoW();
-        set => _SoW = value;
-    }
+    private static CoreSoW SoW => _SoW ??= new CoreSoW();
     private static CoreSoW _SoW;
-    private static CoreIsleOfFotia Fotia
-    {
-        get => _Fotia ??= new CoreIsleOfFotia();
-        set => _Fotia = value;
-    }
+    private static CoreIsleOfFotia Fotia => _Fotia ??= new CoreIsleOfFotia();
     private static CoreIsleOfFotia _Fotia;
-    private static Core13LoC LoC
-    {
-        get => _LoC ??= new Core13LoC();
-        set => _LoC = value;
-    }
+    private static Core13LoC LoC => _LoC ??= new Core13LoC();
     private static Core13LoC _LoC;
-    private static CoreAdvanced Adv
-    {
-        get => _Adv ??= new CoreAdvanced();
-        set => _Adv = value;
-    }
-    private static CoreAdvanced _Adv;
-    private static CoreFarms Farm
-    {
-        get => _Farm ??= new CoreFarms();
-        set => _Farm = value;
-    }
-    private static CoreFarms _Farm;
-    private static CoreAstravia Astravia
-    {
-        get => _Astravia ??= new CoreAstravia();
-        set => _Astravia = value;
-    }
+    private static CoreAstravia Astravia => _Astravia ??= new CoreAstravia();
     private static CoreAstravia _Astravia;
 
     public void ScriptMain(IScriptInterface bot)

--- a/Story/DoAllUltrasStory.cs
+++ b/Story/DoAllUltrasStory.cs
@@ -10,10 +10,14 @@ description: Completes all story prerequisites needed to unlock every Ultra boss
 tags: story, quest, ultra, ezrajal, warden, engineer, tyndarius, speaker, dage, drakath, darkon, drago, all, complete
 */
 //cs_include Scripts/CoreBots.cs
+//cs_include Scripts/CoreStory.cs
+//cs_include Scripts/CoreFarms.cs
+//cs_include Scripts/CoreAdvanced.cs
 //cs_include Scripts/Story/ExaltiaTower.cs
 //cs_include Scripts/Story/ShadowsOfWar/CoreSoW.cs
 //cs_include Scripts/Story/IsleOfFotia/CoreIsleOfFotia.cs
 //cs_include Scripts/Story/LordsofChaos/Core13LoC.cs
+
 //cs_include Scripts/Story/ElegyofMadness(Darkon)/CoreAstravia.cs
 using Skua.Core.Interfaces;
 


### PR DESCRIPTION
Adds a single script that completes every story line required to unlock all Ultra bosses.

Exaltia Tower → Ultra Ezrajal, Ultra Warden, Ultra Engineer
Shadows of War → Ultra Avatar Tyndarius, Ultra Speaker
Isle of Fotia → Ultra Dage
13 Lords of Chaos → Champion Drakath
Elegy of Madness / Astravia → Ultra Drago, Ultra Darkon
Skipped: Ultra Nulgath & Ultra Gramiel (Level 80 only, no story prerequisites).

## Summary by Sourcery

Add a consolidated script to automatically complete all storylines required to unlock most Ultra bosses.

New Features:
- Introduce a DoAllUltrasStory script that sequentially completes prerequisite storylines for multiple Ultra bosses across Exaltia Tower, Shadows of War, Isle of Fotia, 13 Lords of Chaos, and Astravia.

Enhancements:
- Standardize access to existing core story and farming helper classes to centralize Ultra boss unlock progression into a single entry point script.