### PR TITLE
updates to greatblade dungeons

### DIFF
--- a/Ultras/Entwined Eclipse/AscensionoftheEclipse.cs
+++ b/Ultras/Entwined Eclipse/AscensionoftheEclipse.cs
@@ -12,6 +12,7 @@ tags: greatblade, entwined, eclipse, ascend, ascendeclipse, army, taunt, test
 using Newtonsoft.Json;
 using Skua.Core.Interfaces;
 using Skua.Core.Options;
+using Skua.Core.Models.Quests;
 using System;
 using System.IO;
 using System.Linq;
@@ -64,19 +65,19 @@ public class AscendEclipseTest
             true
         ),
         new Option<bool>(
-            "autoGetEnrage",
-            "Auto-Craft Scroll of Enrage",
-            "ON: all accounts auto-farm Mystic Parchment, buy Zealous Ink, and craft Scroll of Enrage. Requires SpellCrafting rank 5.\n" +
-            "OFF: scroll requirement is skipped.",
-            true
-        ),
-        new Option<bool>(
             "oracleClassTauntReset",
             "Oracle Class Taunt Reset",
-            "ON: swaps to Oracle then back before taunt fights to clear the class taunt bug.\n" +
+            "ON: swaps to Oracle then back before taunt fights to clear the class taunt bug. (DOESNT USE POTIONS WHEN ON) \n" +
             "OFF: skips the Oracle swap and only ensures Scroll of Enrage is equipped.",
             true
         ),
+        new Option<bool>(
+            "usePotions",
+            "Use Potions",
+            "DOESNT WORK WHEN Oracle Class Taunt Reset IS ON. (this is by design) \n" +
+            "ON: equips and uses configured class potion sets before starting the dungeon loop. (TONICS and ELIXIRS ONLY) \n" +
+            "OFF: skips tonic/elixir usage.",
+            false)
     };
 
     // Fixed 4-class lineup
@@ -99,6 +100,7 @@ public class AscendEclipseTest
 
     bool autoEnhance;
     bool autoGetEnrage;
+    bool usePotions;
     bool oracleClassTauntReset;
     int runCount;
     int syncCount;
@@ -145,9 +147,10 @@ public class AscendEclipseTest
 
         Core.Logger($"Army mode enabled: {sArmy.Players().Length} accounts, private room #{Core.PrivateRoomNumber}.");
 
-        autoEnhance   = Bot.Config!.Get<bool>("autoEnhance");
-        autoGetEnrage = Bot.Config.Get<bool>("autoGetEnrage");
+        autoEnhance = Bot.Config!.Get<bool>("autoEnhance");
+        autoGetEnrage = true;
         oracleClassTauntReset = Bot.Config.Get<bool>("oracleClassTauntReset");
+        usePotions = Bot.Config.Get<bool>("usePotions");
 
         SetupPartyFromPlayer1();
 
@@ -156,9 +159,14 @@ public class AscendEclipseTest
         if (autoEnhance)
             ApplyEnhancements();
 
-        //UseClassPotions();
+        if (usePotions && !oracleClassTauntReset)
+            UseClassPotions();
+        else if (usePotions && oracleClassTauntReset)
+            Core.Logger("[Potions] Skipping tonic/elixir usage because Oracle Class Taunt Reset is ON.");
 
         PrepareTauntRole();
+
+        TryAcceptDailyQuest(9305, "Frozen Cycle");
 
         try
         {
@@ -206,6 +214,9 @@ public class AscendEclipseTest
 
         // r3 — dual final boss fight (Ascended Solstice + Ascended Midnight simultaneously)
         ArmyKillDualBoss("ascendeclipse", "r3", "Left", $"{runCheckpoint}_07");
+
+        // Daily quest completion
+        TryCompleteDailyQuest(9305, "Ecliptic Offering");
     }
 
     string GetConfiguredClassForCurrentAccount()
@@ -1324,6 +1335,11 @@ public class AscendEclipseTest
 
     void ResetReusableSyncFiles()
     {
+        Core.Logger("[Sync] Moving to /whitemap before clearing reusable sync files.");
+        Core.Join("whitemap", "Enter", "Spawn");
+        WaitForMapName("whitemap", 8000);
+        Bot.Sleep(1000);
+
         bool isPlayer1 = IsConfiguredAccount(Bot.Config!.Get<string>("player1") ?? "");
 
         if (!isPlayer1)
@@ -1947,6 +1963,41 @@ public class AscendEclipseTest
 
     // ── Setup ─────────────────────────────────────────────────────────────────
 
+    void TryAcceptDailyQuest(int questId, string questName)
+    {
+        Quest? quest = Core.InitializeWithRetries(() => Core.EnsureLoad(questId));
+
+        if (quest == null)
+        {
+            Core.Logger($"[Daily] Failed to load {questName} [{questId}]. Skipping.");
+            return;
+        }
+
+        if (Bot.Quests.IsDailyComplete(questId))
+        {
+            Core.Logger($"[Daily] {quest.Name} [{quest.ID}] is not available right now.");
+            return;
+        }
+
+        Core.Logger($"[Daily] Accepting {quest.Name} [{quest.ID}].");
+        Core.EnsureAccept(questId);
+        Core.AddDrop(quest.Rewards.Select(x => x.Name).ToArray());
+        Core.AddDrop(quest.Requirements.Select(x => x.Name).ToArray());
+    }
+
+    void TryCompleteDailyQuest(int questId, string rewardName)
+    {
+        if (!Bot.Quests.IsInProgress(questId))
+            return;
+
+        Core.Logger($"[Daily] Attempting to complete daily quest {questId}.");
+
+        Core.EnsureComplete(questId);
+        Bot.Wait.ForPickup(rewardName);
+
+        Core.Logger($"[Daily] Completed daily quest {questId}.");
+    }
+
     void EquipArmyClasses()
     {
         string username = Core.Username();
@@ -2009,7 +2060,7 @@ public class AscendEclipseTest
                 Adv.EnhanceEquipped(
                     type: EnhancementType.Wizard,
                     hSpecial: HelmSpecial.None,
-                    wSpecial: Adv.uElysium() ? WeaponSpecial.Elysium : WeaponSpecial.Awe_Blast,
+                    wSpecial: Adv.uElysium() ? WeaponSpecial.Elysium : WeaponSpecial.Valiance,
                     cSpecial: CapeSpecial.Penitence
                 );
                 break;
@@ -2057,20 +2108,20 @@ public class AscendEclipseTest
         switch (className.ToLower())
         {
             case "legion revenant":
-                UsePotionSet("Sage Tonic", "Potent Revitalize Elixir");
+                UsePotionSet("Fate Tonic", "Battle Elixir");
                 break;
 
             case "stonecrusher":
             case "infinity titan":
-                UsePotionSet("Might Tonic", "Potent Revitalize Elixir");
+                UsePotionSet("Might Tonic", "Divine Elixir");
                 break;
 
             case "archpaladin":
-                UsePotionSet("Fate Tonic", "Potent Revitalize Elixir");
+                UsePotionSet("Fate Tonic", "Battle Elixir");
                 break;
 
             case "lord of order":
-                UsePotionSet("Fate Tonic", "Potent Revitalize Elixir");
+                UsePotionSet("Fate Tonic", "Divine Elixir");
                 break;
 
             default:
@@ -2079,13 +2130,10 @@ public class AscendEclipseTest
         }
     }
 
-    void UsePotionSet(string tonic, string elixir, string? potion = null)
+    void UsePotionSet(string tonic, string elixir)
     {
         UsePotionItem(tonic);
         UsePotionItem(elixir);
-
-        if (!string.IsNullOrWhiteSpace(potion))
-            UsePotionItem(potion);
     }
 
     void UsePotionItem(string itemName)

--- a/Ultras/Entwined Eclipse/MidnightSun.cs
+++ b/Ultras/Entwined Eclipse/MidnightSun.cs
@@ -12,6 +12,7 @@ tags: greatblade, entwined, eclipse, midnight, sun, farm, test, army
 using Newtonsoft.Json;
 using Skua.Core.Interfaces;
 using Skua.Core.Options;
+using Skua.Core.Models.Quests;
 using System;
 using System.IO;
 using System.Linq;
@@ -64,11 +65,11 @@ public class MidnightSunTest
             true
         ),
         new Option<bool>(
-            "autoGetEnrage",
-            "Auto-Craft Scroll of Enrage",
-            "ON: all accounts auto-farm Mystic Parchment, buy Zealous Ink, and craft Scroll of Enrage. Requires SpellCrafting rank 5.\n" +
-            "OFF: skipped — make sure Scroll of Enrage is already equipped.",
-            true
+            "usePotions",
+            "Use Potions",
+            "ON: equips and uses configured class potion sets before starting the dungeon loop. (TONICS and ELIXIRS ONLY)\n" +
+            "OFF: skips potion usage.",
+            false
         ),
     };
 
@@ -87,6 +88,7 @@ public class MidnightSunTest
 
     bool autoEnhance;
     bool autoGetEnrage;
+    bool usePotions;
     int runCount;
     bool syncFilesClearedOnStartup;
 
@@ -133,12 +135,21 @@ public class MidnightSunTest
 
         Core.Logger($"Army mode enabled: {sArmy.Players().Length} accounts, private room #{Core.PrivateRoomNumber}.");
 
+        autoEnhance = Bot.Config!.Get<bool>("autoEnhance");
+        autoGetEnrage = true;
+        usePotions = Bot.Config.Get<bool>("usePotions");
+
         EquipArmyClasses();
 
         if (autoEnhance)
             ApplyEnhancements();
 
+        if (usePotions)
+            UseClassPotions();
+
         PrepareTauntRole();
+
+        TryAcceptDailyQuest(9304, "Dawn Breaks");
 
         Core.AddDrop(SliverSunlight);
 
@@ -184,6 +195,8 @@ public class MidnightSunTest
 
         // Shrine boss: Hollow Solstice — player1+2 alternate on "The Sun Converges"
         ArmyKillShrineBoss("midnightsun", "r3", "Left", "Hollow Solstice", $"{runCheckpoint}_06");
+
+        TryCompleteDailyQuest(9304, "Sliver of Sunlight");
     }
 
     // ── Army helpers ──────────────────────────────────────────────────────────
@@ -275,6 +288,12 @@ public class MidnightSunTest
 
     void ResetReusableSyncFiles()
     {
+
+        Core.Logger("[Sync] Moving to /whitemap before clearing reusable sync files.");
+        Core.Join("whitemap", "Enter", "Spawn");
+        WaitForMapName("whitemap", 8000);
+        Bot.Sleep(1000);
+
         bool isPlayer1 = IsConfiguredAccount(Bot.Config!.Get<string>("player1") ?? "");
 
         if (!isPlayer1)
@@ -1131,6 +1150,41 @@ public class MidnightSunTest
         }
     }
 
+    void TryAcceptDailyQuest(int questId, string questName)
+    {
+        Quest? quest = Core.InitializeWithRetries(() => Core.EnsureLoad(questId));
+
+        if (quest == null)
+        {
+            Core.Logger($"[Daily] Failed to load {questName} [{questId}]. Skipping.");
+            return;
+        }
+
+        if (Bot.Quests.IsDailyComplete(questId))
+        {
+            Core.Logger($"[Daily] {quest.Name} [{quest.ID}] is not available right now.");
+            return;
+        }
+
+        Core.Logger($"[Daily] Accepting {quest.Name} [{quest.ID}].");
+        Core.EnsureAccept(questId);
+        Core.AddDrop(quest.Rewards.Select(x => x.Name).ToArray());
+        Core.AddDrop(quest.Requirements.Select(x => x.Name).ToArray());
+    }
+
+    void TryCompleteDailyQuest(int questId, string rewardName)
+    {
+        if (!Bot.Quests.IsInProgress(questId))
+            return;
+
+        Core.Logger($"[Daily] Attempting to complete daily quest {questId}.");
+
+        Core.EnsureComplete(questId);
+        Bot.Wait.ForPickup(rewardName);
+
+        Core.Logger($"[Daily] Completed daily quest {questId}.");
+    }
+
     void ResetDungeonInstance(string nextMap, string checkpoint)
     {
         SyncArmy($"{checkpoint}_reset_ready.sync");
@@ -1285,6 +1339,61 @@ public class MidnightSunTest
         !string.IsNullOrWhiteSpace(className)
         && string.Equals(Bot.Player.CurrentClass?.Name, className, StringComparison.OrdinalIgnoreCase);
 
+    void UseClassPotions()
+    {
+        string className = Bot.Player.CurrentClass?.Name ?? "";
+
+        Core.Logger($"{Core.Username()} using potions for {className}...");
+
+        switch (className.ToLower())
+        {
+            case "legion revenant":
+                UsePotionSet("Fate Tonic", "Battle Elixir");
+                break;
+
+            case "stonecrusher":
+            case "infinity titan":
+                UsePotionSet("Might Tonic", "Divine Elixir");
+                break;
+
+            case "archpaladin":
+                UsePotionSet("Fate Tonic", "Battle Elixir");
+                break;
+
+            case "lord of order":
+                UsePotionSet("Fate Tonic", "Divine Elixir");
+                break;
+
+            default:
+                Core.Logger($"[Potions] No potion profile for '{className}' — skipping.");
+                break;
+        }
+    }
+
+    void UsePotionSet(string tonic, string elixir)
+    {
+        UsePotionItem(tonic);
+        UsePotionItem(elixir);
+    }
+
+    void UsePotionItem(string itemName)
+    {
+        if (!Core.CheckInventory(itemName))
+        {
+            Core.Logger($"[Potions] Missing {itemName}; skipping.");
+            return;
+        }
+
+        if (!Bot.Inventory.IsEquipped(itemName))
+        {
+            Bot.Inventory.EquipUsableItem(itemName);
+            Bot.Sleep(500);
+        }
+
+        Core.UsePotion();
+        Bot.Sleep(1000);
+    }
+
     void ApplyEnhancements()
     {
         string className = Bot.Player.CurrentClass?.Name ?? "";
@@ -1296,7 +1405,7 @@ public class MidnightSunTest
                 Adv.EnhanceEquipped(
                     type: EnhancementType.Wizard,
                     hSpecial: HelmSpecial.None,
-                    wSpecial: Adv.uElysium() ? WeaponSpecial.Elysium : WeaponSpecial.Awe_Blast,
+                    wSpecial: Adv.uElysium() ? WeaponSpecial.Elysium : WeaponSpecial.Valiance,
                     cSpecial: CapeSpecial.Penitence
                 );
                 break;

--- a/Ultras/Entwined Eclipse/SolsticeMoon.cs
+++ b/Ultras/Entwined Eclipse/SolsticeMoon.cs
@@ -12,6 +12,7 @@ tags: solstice, moon, hollow midnight, lunar haze, army, taunt, test
 using Newtonsoft.Json;
 using Skua.Core.Interfaces;
 using Skua.Core.Options;
+using Skua.Core.Models.Quests;
 using System;
 using System.IO;
 using System.Linq;
@@ -65,18 +66,11 @@ public class SolsticeMoonTest
             true
         ),
         new Option<bool>(
-            "autoGetEnrage",
-            "Auto-Craft Scroll of Enrage",
-            "ON: all accounts auto-farm Mystic Parchment, buy Zealous Ink, and craft Scroll of Enrage before farming. Requires SpellCrafting rank 5.\n" +
-            "OFF: scroll requirement is skipped.",
-            true
-        ),
-        new Option<bool>(
-            "checkUsableSlotBeforeBossRooms",
-            "Check Usable Slot Before Boss Rooms",
-            "ON: before each taunt boss room, re-checks that Scroll of Enrage is equipped and waits briefly for the usable slot to be ready. " +
-            "This helps recover from AQW/Skua usable-slot desync before dangerous taunt checks.",
-            true
+            "usePotions",
+            "Use Potions",
+            "ON: equips and uses configured class potion sets before starting the dungeon loop. (TONICS and ELIXIRS ONLY)\n" +
+            "OFF: skips potion usage.",
+            false
         ),
     };
 
@@ -125,6 +119,7 @@ public class SolsticeMoonTest
     bool autoEnhance;
     bool autoGetEnrage;
     bool checkUsableSlotBeforeBossRooms;
+    bool usePotions;
 
     // Fixed 4-class lineup matching the working reference script
     const string player1Class = "Legion Revenant";  // Lunar Haze taunter
@@ -180,15 +175,21 @@ public class SolsticeMoonTest
 
 
         autoEnhance = Bot.Config.Get<bool>("autoEnhance");
-        autoGetEnrage = Bot.Config.Get<bool>("autoGetEnrage");
-        checkUsableSlotBeforeBossRooms = Bot.Config.Get<bool>("checkUsableSlotBeforeBossRooms");
+        autoGetEnrage = true;
+        checkUsableSlotBeforeBossRooms = true;
+        usePotions = Bot.Config.Get<bool>("usePotions");
 
         EquipArmyClasses();
 
         if (autoEnhance)
             ApplyEnhancements();
 
+        if (usePotions)
+            UseClassPotions();
+
         PrepareTauntRole();
+
+        TryAcceptDailyQuest(9303, "Night Falls");
 
         Core.AddDrop(SliverMoonlight);
 
@@ -336,6 +337,12 @@ public class SolsticeMoonTest
 
     void ResetReusableSyncFiles()
     {
+
+        Core.Logger("[Sync] Moving to /whitemap before clearing reusable sync files.");
+        Core.Join("whitemap", "Enter", "Spawn");
+        WaitForMapName("whitemap", 8000);
+        Bot.Sleep(1000);
+
         bool isPlayer1 = IsConfiguredAccount(Bot.Config!.Get<string>("player1") ?? "");
 
         if (!isPlayer1)
@@ -697,6 +704,41 @@ public class SolsticeMoonTest
         return Bot.Inventory.Items
             .FirstOrDefault(item => item.Name.Equals(itemName, StringComparison.OrdinalIgnoreCase))
             ?.Quantity ?? 0;
+    }
+
+    void TryAcceptDailyQuest(int questId, string questName)
+    {
+        Quest? quest = Core.InitializeWithRetries(() => Core.EnsureLoad(questId));
+
+        if (quest == null)
+        {
+            Core.Logger($"[Daily] Failed to load {questName} [{questId}]. Skipping.");
+            return;
+        }
+
+        if (Bot.Quests.IsDailyComplete(questId))
+        {
+            Core.Logger($"[Daily] {quest.Name} [{quest.ID}] is not available right now.");
+            return;
+        }
+
+        Core.Logger($"[Daily] Accepting {quest.Name} [{quest.ID}].");
+        Core.EnsureAccept(questId);
+        Core.AddDrop(quest.Rewards.Select(x => x.Name).ToArray());
+        Core.AddDrop(quest.Requirements.Select(x => x.Name).ToArray());
+    }
+
+    void TryCompleteDailyQuest(int questId, string rewardName)
+    {
+        if (!Bot.Quests.IsInProgress(questId))
+            return;
+
+        Core.Logger($"[Daily] Attempting to complete daily quest {questId}.");
+
+        Core.EnsureComplete(questId);
+        Bot.Wait.ForPickup(rewardName);
+
+        Core.Logger($"[Daily] Completed daily quest {questId}.");
     }
 
     void RestockEnrageIfLow(string context, int minimumCount = 80)
@@ -1197,7 +1239,7 @@ public class SolsticeMoonTest
                 Adv.EnhanceEquipped(
                     type: EnhancementType.Wizard,
                     hSpecial: HelmSpecial.None,
-                    wSpecial: Adv.uElysium() ? WeaponSpecial.Elysium : WeaponSpecial.Awe_Blast,
+                    wSpecial: Adv.uElysium() ? WeaponSpecial.Elysium : WeaponSpecial.Valiance,
                     cSpecial: CapeSpecial.Penitence
                 );
                 break;
@@ -1416,8 +1458,10 @@ public class SolsticeMoonTest
 
     void RunSolsticeMoon()
     {
-        ResetReusableSyncFiles();
         int run = ++solsticeRunCount;
+        string runCheckpoint = $"GreatbladeSolstice_{run}";
+
+        ResetReusableSyncFiles();
 
         ResetDungeonInstance("solsticemoon", $"GreatbladeSolstice_{run}");
 
@@ -1452,6 +1496,8 @@ public class SolsticeMoonTest
             $"GreatbladeSolstice_{run}_04",
             moonBoss: true
         );
+
+        TryCompleteDailyQuest(9303, "Sliver of Moonlight");
     }
 
     void MoveSolstice(string checkpoint)
@@ -1475,6 +1521,61 @@ public class SolsticeMoonTest
                 RestartSolstice(checkpoint);
                 break;
         }
+    }
+
+    void UseClassPotions()
+    {
+        string className = Bot.Player.CurrentClass?.Name ?? "";
+
+        Core.Logger($"{Core.Username()} using tonic/elixir for {className}...");
+
+        switch (className.ToLower())
+        {
+            case "legion revenant":
+                UsePotionSet("Fate Tonic", "Battle Elixir");
+                break;
+
+            case "stonecrusher":
+            case "infinity titan":
+                UsePotionSet("Might Tonic", "Divine Elixir");
+                break;
+
+            case "archpaladin":
+                UsePotionSet("Fate Tonic", "Battle Elixir");
+                break;
+
+            case "lord of order":
+                UsePotionSet("Fate Tonic", "Divine Elixir");
+                break;
+
+            default:
+                Core.Logger($"[Potions] No tonic/elixir profile for '{className}' — skipping.");
+                break;
+        }
+    }
+
+    void UsePotionSet(string tonic, string elixir)
+    {
+        UsePotionItem(tonic);
+        UsePotionItem(elixir);
+    }
+
+    void UsePotionItem(string itemName)
+    {
+        if (!Core.CheckInventory(itemName))
+        {
+            Core.Logger($"[Potions] Missing {itemName}; skipping.");
+            return;
+        }
+
+        if (!Bot.Inventory.IsEquipped(itemName))
+        {
+            Bot.Inventory.EquipUsableItem(itemName);
+            Bot.Sleep(500);
+        }
+
+        Core.UsePotion();
+        Bot.Sleep(1000);
     }
 
     void RestartSolstice(string checkpoint)

--- a/Ultras/Entwined Eclipse/SolsticeMoon.cs
+++ b/Ultras/Entwined Eclipse/SolsticeMoon.cs
@@ -1463,7 +1463,7 @@ public class SolsticeMoonTest
 
         ResetReusableSyncFiles();
 
-        ResetDungeonInstance("solsticemoon", $"GreatbladeSolstice_{run}");
+        ResetDungeonInstance("solsticemoon", runCheckpoint);
 
         ArmyKillMonster("solsticemoon", "Enter", "Left", "*", $"GreatbladeSolstice_{run}_01");
 


### PR DESCRIPTION
- add optional potion usage to all dungeons (off by default) 

- added daily quest support

- optimizations

## Summary by Sourcery

Add optional class-based potion usage and daily quest handling to the Entwined Eclipse greatblade dungeons while adjusting related configs and minor optimization behavior.

New Features:
- Introduce a configurable Use Potions option for each Entwined Eclipse dungeon that applies class-specific tonic and elixir sets at run start.
- Add support for automatically accepting and completing the Entwined Eclipse daily quests tied to each dungeon run.

Enhancements:
- Standardize weapon enhancement fallback from Awe_Blast to Valiance for the supported classes in all three dungeons.
- Always enable internal Scroll of Enrage automation while simplifying related configuration options.
- Ensure reusable sync file resets first move players into a safe whitemap hub before clearing state to reduce desync issues.
- Adjust Ascension of the Eclipse potion profiles to use tonic and elixir combinations consistent with the other dungeons and remove unused extra potion usage.