### PR TITLE
potion refresh added and it now gets it, added sell hallowed remains if max stack

### DIFF
--- a/Ultras/Entwined Eclipse/AscensionoftheEclipse.cs
+++ b/Ultras/Entwined Eclipse/AscensionoftheEclipse.cs
@@ -1870,7 +1870,7 @@ public class AscendEclipseTest
         WaitForMapName("whitemap", 8000);
         Bot.Sleep(1000);
         SyncArmy($"{checkpoint}_all_in_whitemap.sync");
-
+        SellHallowedRemainsIfMax();
         RefreshPotionsIfAurasMissing();
         RestockEnrageIfLow($"Before {checkpoint}", minimumCount: 80);
         EnsureTauntItemEquipped("[Restock]");
@@ -1887,6 +1887,23 @@ public class AscendEclipseTest
         return Bot.Inventory.Items
             .FirstOrDefault(item => item.Name.Equals(itemName, StringComparison.OrdinalIgnoreCase))
             ?.Quantity ?? 0;
+    }
+
+    void SellHallowedRemainsIfMax()
+    {
+        const string itemName = "Hallowed Remains";
+        const int maxStack = 500;
+
+        int quantity = Bot.Inventory.GetQuantity(itemName);
+
+        if (quantity < maxStack)
+            return;
+
+        Core.Logger($"[Inventory] {itemName} is at max stack ({quantity}/{maxStack}). Selling all.");
+
+        Core.SellItem(itemName, all: true);
+
+        Bot.Sleep(1000);
     }
 
     void RestockEnrageIfLow(string context, int minimumCount = 80)

--- a/Ultras/Entwined Eclipse/AscensionoftheEclipse.cs
+++ b/Ultras/Entwined Eclipse/AscensionoftheEclipse.cs
@@ -1871,7 +1871,10 @@ public class AscendEclipseTest
         Bot.Sleep(1000);
         SyncArmy($"{checkpoint}_all_in_whitemap.sync");
 
+        RefreshPotionsIfAurasMissing();
         RestockEnrageIfLow($"Before {checkpoint}", minimumCount: 80);
+        EnsureTauntItemEquipped("[Restock]");
+
         SyncArmy($"{checkpoint}_restock_done.sync");
 
         JoinShrineDungeon(nextMap, "Enter", "Left", force: true);
@@ -2108,20 +2111,20 @@ public class AscendEclipseTest
         switch (className.ToLower())
         {
             case "legion revenant":
-                UsePotionSet("Fate Tonic", "Battle Elixir");
+                UsePotionSet("Sage Tonic", "Potent Malevolence Elixir");
                 break;
 
             case "stonecrusher":
             case "infinity titan":
-                UsePotionSet("Might Tonic", "Divine Elixir");
+                UsePotionSet("Might Tonic", "Potent Battle Elixir");
                 break;
 
             case "archpaladin":
-                UsePotionSet("Fate Tonic", "Battle Elixir");
+                UsePotionSet("Fate Tonic", "Potent Battle Elixir");
                 break;
 
             case "lord of order":
-                UsePotionSet("Fate Tonic", "Divine Elixir");
+                UsePotionSet("Fate Tonic", "Potent Destruction Elixir");
                 break;
 
             default:
@@ -2139,8 +2142,11 @@ public class AscendEclipseTest
     void UsePotionItem(string itemName)
     {
         if (!Core.CheckInventory(itemName))
+            BuyAlchemyPotion(itemName);
+
+        if (!Core.CheckInventory(itemName))
         {
-            Core.Logger($"[Potions] Missing {itemName}; skipping.");
+            Core.Logger($"[Potions] Failed to get {itemName}; skipping.");
             return;
         }
 
@@ -2152,6 +2158,97 @@ public class AscendEclipseTest
 
         Core.UsePotion();
         Bot.Sleep(1000);
+    }
+
+    void BuyAlchemyPotion(string itemName)
+    {
+        if (string.IsNullOrWhiteSpace(itemName) || Core.CheckInventory(itemName))
+        {
+            if (!string.IsNullOrWhiteSpace(itemName))
+                Core.Logger($"[Potions] Have: {itemName}");
+            return;
+        }
+
+        const int shopId = 2036;
+        const string map = "alchemyacademy";
+        const string voucher = "Gold Voucher 500k";
+
+        void NeedVoucher(int wanted)
+        {
+            int missing = Math.Max(0, wanted - Bot.Inventory.GetQuantity(voucher));
+
+            if (missing > 0)
+            {
+                Core.Logger($"[Potions] Buying {missing}x {voucher}.");
+                Engine.BuyItem(voucher, shopId, map, missing);
+                Bot.Sleep(500);
+            }
+        }
+
+        void BuyPotion(int count)
+        {
+            Core.Logger($"[Potions] Buying {count}x {itemName}.");
+            Engine.BuyItem(itemName, shopId, map, count, calculateRemaining: false);
+            Bot.Sleep(500);
+        }
+
+        switch (itemName)
+        {
+            case "Might Tonic":
+            case "Sage Tonic":
+            case "Fate Tonic":
+                if (!Engine.Faction("Alchemy", 8))
+                {
+                    Core.Logger("[Potions] Alchemy rank 8 required for tonic.");
+                    return;
+                }
+
+                NeedVoucher(2);
+                BuyPotion(10);
+                break;
+
+            case "Potent Malevolence Elixir":
+            case "Potent Battle Elixir":
+            case "Potent Destruction Elixir":
+                NeedVoucher(4);
+                BuyPotion(8);
+                break;
+
+            default:
+                Core.Logger($"[Potions] Unknown potion: {itemName}");
+                return;
+        }
+    }
+
+    void RefreshPotionsIfAurasMissing()
+    {
+        if (!usePotions)
+            return;
+
+        if (oracleClassTauntReset)
+        {
+            Core.Logger("[Potions] Skipping potion refresh because Oracle Class Taunt Reset is ON.");
+            return;
+        }            
+
+        bool hasTonic =
+            Bot.Self.HasActiveAura("Sage") ||
+            Bot.Self.HasActiveAura("Might") ||
+            Bot.Self.HasActiveAura("Fate");
+
+        bool hasElixir =
+            Bot.Self.HasActiveAura("Potent Malevolence Elixir") ||
+            Bot.Self.HasActiveAura("Potent Battle Elixir") ||
+            Bot.Self.HasActiveAura("Potent Destruction Elixir");
+
+        if (hasTonic && hasElixir)
+        {
+            Core.Logger("[Potions] Potion auras still active. Skipping potion refresh.");
+            return;
+        }
+
+        Core.Logger("[Potions] Missing potion aura. Refreshing class potions.");
+        UseClassPotions();
     }
 
     void PrepareTauntRole()

--- a/Ultras/Entwined Eclipse/MidnightSun.cs
+++ b/Ultras/Entwined Eclipse/MidnightSun.cs
@@ -1193,7 +1193,9 @@ public class MidnightSunTest
         WaitForMapName("whitemap", 8000);
         Bot.Sleep(1000);
         SyncArmy($"{checkpoint}_all_in_whitemap.sync");
+        RefreshPotionsIfAurasMissing();
         RestockEnrageIfLow($"Before {checkpoint}", minimumCount: 80);
+        EnsureEnrageEquipped("Restock");
         SyncArmy($"{checkpoint}_restock_done.sync");
         JoinShrineDungeon(nextMap, "Enter", "Left", force: true);
         Bot.Sleep(1000);
@@ -1205,6 +1207,31 @@ public class MidnightSunTest
         return Bot.Inventory.Items
             .FirstOrDefault(item => item.Name.Equals(itemName, StringComparison.OrdinalIgnoreCase))
             ?.Quantity ?? 0;
+    }
+
+    void RefreshPotionsIfAurasMissing()
+    {
+        if (!usePotions)
+            return;
+
+        bool hasTonic =
+            Bot.Self.HasActiveAura("Sage") ||
+            Bot.Self.HasActiveAura("Might") ||
+            Bot.Self.HasActiveAura("Fate");
+
+        bool hasElixir =
+            Bot.Self.HasActiveAura("Potent Malevolence Elixir") ||
+            Bot.Self.HasActiveAura("Potent Battle Elixir") ||
+            Bot.Self.HasActiveAura("Potent Destruction Elixir");
+
+        if (hasTonic && hasElixir)
+        {
+            Core.Logger("[Potions] Potion auras still active. Skipping potion refresh.");
+            return;
+        }
+
+        Core.Logger("[Potions] Missing potion aura. Refreshing class potions.");
+        UseClassPotions();
     }
 
     void RestockEnrageIfLow(string context, int minimumCount = 80)
@@ -1348,20 +1375,20 @@ public class MidnightSunTest
         switch (className.ToLower())
         {
             case "legion revenant":
-                UsePotionSet("Fate Tonic", "Battle Elixir");
+                UsePotionSet("Sage Tonic", "Potent Malevolence Elixir");
                 break;
 
             case "stonecrusher":
             case "infinity titan":
-                UsePotionSet("Might Tonic", "Divine Elixir");
+                UsePotionSet("Might Tonic", "Potent Battle Elixir");
                 break;
 
             case "archpaladin":
-                UsePotionSet("Fate Tonic", "Battle Elixir");
+                UsePotionSet("Fate Tonic", "Potent Battle Elixir");
                 break;
 
             case "lord of order":
-                UsePotionSet("Fate Tonic", "Divine Elixir");
+                UsePotionSet("Fate Tonic", "Potent Destruction Elixir");
                 break;
 
             default:
@@ -1379,8 +1406,11 @@ public class MidnightSunTest
     void UsePotionItem(string itemName)
     {
         if (!Core.CheckInventory(itemName))
+            BuyAlchemyPotion(itemName);
+
+        if (!Core.CheckInventory(itemName))
         {
-            Core.Logger($"[Potions] Missing {itemName}; skipping.");
+            Core.Logger($"[Potions] Failed to get {itemName}; skipping.");
             return;
         }
 
@@ -1392,6 +1422,66 @@ public class MidnightSunTest
 
         Core.UsePotion();
         Bot.Sleep(1000);
+    }
+
+    void BuyAlchemyPotion(string itemName)
+    {
+        if (string.IsNullOrWhiteSpace(itemName) || Core.CheckInventory(itemName))
+        {
+            if (!string.IsNullOrWhiteSpace(itemName))
+                Core.Logger($"[Potions] Have: {itemName}");
+            return;
+        }
+
+        const int shopId = 2036;
+        const string map = "alchemyacademy";
+        const string voucher = "Gold Voucher 500k";
+
+        void NeedVoucher(int wanted)
+        {
+            int missing = Math.Max(0, wanted - Bot.Inventory.GetQuantity(voucher));
+
+            if (missing > 0)
+            {
+                Core.Logger($"[Potions] Buying {missing}x {voucher}.");
+                Engine.BuyItem(voucher, shopId, map, missing);
+                Bot.Sleep(500);
+            }
+        }
+
+        void BuyPotion(int count)
+        {
+            Core.Logger($"[Potions] Buying {count}x {itemName}.");
+            Engine.BuyItem(itemName, shopId, map, count, calculateRemaining: false);
+            Bot.Sleep(500);
+        }
+
+        switch (itemName)
+        {
+            case "Might Tonic":
+            case "Sage Tonic":
+            case "Fate Tonic":
+                if (!Engine.Faction("Alchemy", 8))
+                {
+                    Core.Logger("[Potions] Alchemy rank 8 required for tonic.");
+                    return;
+                }
+
+                NeedVoucher(2);
+                BuyPotion(10);
+                break;
+
+            case "Potent Malevolence Elixir":
+            case "Potent Battle Elixir":
+            case "Potent Destruction Elixir":
+                NeedVoucher(4);
+                BuyPotion(8);
+                break;
+
+            default:
+                Core.Logger($"[Potions] Unknown potion: {itemName}");
+                return;
+        }
     }
 
     void ApplyEnhancements()

--- a/Ultras/Entwined Eclipse/MidnightSun.cs
+++ b/Ultras/Entwined Eclipse/MidnightSun.cs
@@ -1193,6 +1193,7 @@ public class MidnightSunTest
         WaitForMapName("whitemap", 8000);
         Bot.Sleep(1000);
         SyncArmy($"{checkpoint}_all_in_whitemap.sync");
+        SellHallowedRemainsIfMax();
         RefreshPotionsIfAurasMissing();
         RestockEnrageIfLow($"Before {checkpoint}", minimumCount: 80);
         EnsureEnrageEquipped("Restock");
@@ -1207,6 +1208,23 @@ public class MidnightSunTest
         return Bot.Inventory.Items
             .FirstOrDefault(item => item.Name.Equals(itemName, StringComparison.OrdinalIgnoreCase))
             ?.Quantity ?? 0;
+    }
+
+    void SellHallowedRemainsIfMax()
+    {
+        const string itemName = "Hallowed Remains";
+        const int maxStack = 500;
+
+        int quantity = Bot.Inventory.GetQuantity(itemName);
+
+        if (quantity < maxStack)
+            return;
+
+        Core.Logger($"[Inventory] {itemName} is at max stack ({quantity}/{maxStack}). Selling all.");
+
+        Core.SellItem(itemName, all: true);
+
+        Bot.Sleep(1000);
     }
 
     void RefreshPotionsIfAurasMissing()

--- a/Ultras/Entwined Eclipse/SolsticeMoon.cs
+++ b/Ultras/Entwined Eclipse/SolsticeMoon.cs
@@ -690,7 +690,10 @@ public class SolsticeMoonTest
 
         SyncArmy($"{checkpoint}_all_in_whitemap.sync");
 
+        RefreshPotionsIfAurasMissing();
         RestockEnrageIfLow($"Before {checkpoint}", minimumCount: 80);
+        EnsureEnrageEquipped("Restock");
+
         SyncArmy($"{checkpoint}_restock_done.sync");
 
         JoinShrineDungeon(nextMap, "Enter", "Left", force: true);
@@ -1532,20 +1535,20 @@ public class SolsticeMoonTest
         switch (className.ToLower())
         {
             case "legion revenant":
-                UsePotionSet("Fate Tonic", "Battle Elixir");
+                UsePotionSet("Sage Tonic", "Potent Malevolence Elixir");
                 break;
 
             case "stonecrusher":
             case "infinity titan":
-                UsePotionSet("Might Tonic", "Divine Elixir");
+                UsePotionSet("Might Tonic", "Potent Battle Elixir");
                 break;
 
             case "archpaladin":
-                UsePotionSet("Fate Tonic", "Battle Elixir");
+                UsePotionSet("Fate Tonic", "Potent Battle Elixir");
                 break;
 
             case "lord of order":
-                UsePotionSet("Fate Tonic", "Divine Elixir");
+                UsePotionSet("Fate Tonic", "Potent Destruction Elixir");
                 break;
 
             default:
@@ -1563,8 +1566,11 @@ public class SolsticeMoonTest
     void UsePotionItem(string itemName)
     {
         if (!Core.CheckInventory(itemName))
+            BuyAlchemyPotion(itemName);
+
+        if (!Core.CheckInventory(itemName))
         {
-            Core.Logger($"[Potions] Missing {itemName}; skipping.");
+            Core.Logger($"[Potions] Failed to get {itemName}; skipping.");
             return;
         }
 
@@ -1576,6 +1582,90 @@ public class SolsticeMoonTest
 
         Core.UsePotion();
         Bot.Sleep(1000);
+    }
+    void RefreshPotionsIfAurasMissing()
+    {
+        if (!usePotions)
+            return;
+
+        bool hasTonic =
+            Bot.Self.HasActiveAura("Sage") ||
+            Bot.Self.HasActiveAura("Might") ||
+            Bot.Self.HasActiveAura("Fate");
+
+        bool hasElixir =
+            Bot.Self.HasActiveAura("Potent Malevolence Elixir") ||
+            Bot.Self.HasActiveAura("Potent Battle Elixir") ||
+            Bot.Self.HasActiveAura("Potent Destruction Elixir");
+
+        if (hasTonic && hasElixir)
+        {
+            Core.Logger("[Potions] Potion auras still active. Skipping potion refresh.");
+            return;
+        }
+
+        Core.Logger("[Potions] Missing potion aura. Refreshing class potions.");
+        UseClassPotions();
+    }
+
+    void BuyAlchemyPotion(string itemName)
+    {
+        if (string.IsNullOrWhiteSpace(itemName) || Core.CheckInventory(itemName))
+        {
+            if (!string.IsNullOrWhiteSpace(itemName))
+                Core.Logger($"[Potions] Have: {itemName}");
+            return;
+        }
+
+        const int shopId = 2036;
+        const string map = "alchemyacademy";
+        const string voucher = "Gold Voucher 500k";
+
+        void NeedVoucher(int wanted)
+        {
+            int missing = Math.Max(0, wanted - Bot.Inventory.GetQuantity(voucher));
+
+            if (missing > 0)
+            {
+                Core.Logger($"[Potions] Buying {missing}x {voucher}.");
+                Engine.BuyItem(voucher, shopId, map, missing);
+                Bot.Sleep(500);
+            }
+        }
+
+        void BuyPotion(int count)
+        {
+            Core.Logger($"[Potions] Buying {count}x {itemName}.");
+            Engine.BuyItem(itemName, shopId, map, count, calculateRemaining: false);
+            Bot.Sleep(500);
+        }
+
+        switch (itemName)
+        {
+            case "Might Tonic":
+            case "Sage Tonic":
+            case "Fate Tonic":
+                if (!Engine.Faction("Alchemy", 8))
+                {
+                    Core.Logger("[Potions] Alchemy rank 8 required for tonic.");
+                    return;
+                }
+
+                NeedVoucher(2);
+                BuyPotion(10);
+                break;
+
+            case "Potent Malevolence Elixir":
+            case "Potent Battle Elixir":
+            case "Potent Destruction Elixir":
+                NeedVoucher(4);
+                BuyPotion(8);
+                break;
+
+            default:
+                Core.Logger($"[Potions] Unknown potion: {itemName}");
+                return;
+        }
     }
 
     void RestartSolstice(string checkpoint)

--- a/Ultras/Entwined Eclipse/SolsticeMoon.cs
+++ b/Ultras/Entwined Eclipse/SolsticeMoon.cs
@@ -689,7 +689,8 @@ public class SolsticeMoonTest
         Bot.Sleep(1000);
 
         SyncArmy($"{checkpoint}_all_in_whitemap.sync");
-
+        
+        SellHallowedRemainsIfMax();
         RefreshPotionsIfAurasMissing();
         RestockEnrageIfLow($"Before {checkpoint}", minimumCount: 80);
         EnsureEnrageEquipped("Restock");
@@ -707,6 +708,23 @@ public class SolsticeMoonTest
         return Bot.Inventory.Items
             .FirstOrDefault(item => item.Name.Equals(itemName, StringComparison.OrdinalIgnoreCase))
             ?.Quantity ?? 0;
+    }
+
+    void SellHallowedRemainsIfMax()
+    {
+        const string itemName = "Hallowed Remains";
+        const int maxStack = 500;
+
+        int quantity = Bot.Inventory.GetQuantity(itemName);
+
+        if (quantity < maxStack)
+            return;
+
+        Core.Logger($"[Inventory] {itemName} is at max stack ({quantity}/{maxStack}). Selling all.");
+
+        Core.SellItem(itemName, all: true);
+
+        Bot.Sleep(1000);
     }
 
     void TryAcceptDailyQuest(int questId, string questName)


### PR DESCRIPTION
checks for potion aura and if its not there then it will refresh. 
it will also now get and buy the potions in the gebo merge shop at /alchemyacademy if its missing from inventory

sells hallowed remains if its at max stack as well

## Summary by Sourcery

Add automated potion refresh and purchasing for dungeon scripts, updating class-specific potion loadouts and integrating refresh into dungeon reset flows.

New Features:
- Automatically refresh class potions when their auras are missing during dungeon resets.
- Automatically purchase required tonics and potent elixirs from the Alchemy Academy merge shop, including necessary gold vouchers, when not in inventory.

Enhancements:
- Update class potion sets to use Sage/Might/Fate tonics paired with the appropriate potent elixirs for supported classes.
- Improve dungeon reset sequences to ensure taunt/enrage items are equipped when restocking and to skip potion refresh when Oracle taunt reset is active.
- Clarify potion logging messages when potions cannot be obtained.